### PR TITLE
Fix syntax error in DeployHelpers.s.sol

### DIFF
--- a/packages/foundry/script/DeployHelpers.s.sol
+++ b/packages/foundry/script/DeployHelpers.s.sol
@@ -38,7 +38,7 @@ contract ScaffoldETHDeploy is Script {
 
   function _startBroadcast() internal returns (address) {
     vm.startBroadcast();
-    (, address _deployer,) = vm.readCallers();
+    (, address _deployer) = vm.readCallers();
 
     if (block.chainid == 31337 && _deployer.balance == 0) {
       try this.anvil_setBalance(_deployer, ANVIL_BASE_BALANCE) {


### PR DESCRIPTION
In Solidity 0.8.x, a trailing comma (a comma after the last element) in tuple unpacking is not allowed and will result in a syntax error.